### PR TITLE
Convert shorts URL to watch URL

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,6 @@
 chrome.tabs.onUpdated.addListener((tabId, tab, changeInfo) => {
   if (changeInfo.url.includes("youtube.com/shorts")) {
-    chrome.tabs.sendMessage(tabId, {
-      type: "NEW"
-    });
+    chrome.tabs.update(changeInfo.id, {url: changeInfo.url.replace("shorts", "watch")});
   }
-  });
+});
   

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,12 +1,1 @@
-(() => {
-
-    chrome.runtime.onMessage.addListener((obj) => {
-        const {type} = obj;
-
-        if (type === "NEW") {
-            shortsContainer = document.getElementById("shorts-container");
-            shortsContainer.remove();
-        }
-    });
-
-})();
+(()=>{})();

--- a/readme.md
+++ b/readme.md
@@ -2,46 +2,33 @@
 
 ![YouTube Shorts Blocker Logo](assets/logo1.png)
 
-YouTube Shorts Blocker is a browser extension designed to block YouTube Shorts from appearing in your YouTube feed. Say goodbye to endless scrolling through short videos and regain control over your YouTube experience.
+YouTube Shorts Blocker is a browser extension designed to block YouTube Shorts from appearing in your YouTube feed.
+Say goodbye to endless scrolling through short videos and regain control over your YouTube experience.
 
 ## Features
 
-- Doesn't allow you to play YouTube Shorts.
+- Plays YouTube Shorts like full videos to avoid scrolling.
 - Simple and lightweight extension with minimal setup.
 - Works seamlessly across various web browsers.
 
 ## How to Install
 
-### Google Chrome
-
 1. Download the extension ZIP file from the [latest release](https://github.com/sumanbmondal/youtube-shorts-blocker/releases/latest).
 2. Extract the ZIP file to a folder on your computer.
-3. Open Google Chrome and navigate to `chrome://extensions`.
-4. Enable "Developer mode" using the toggle switch in the top-right corner.
-5. Click on the "Load unpacked" button and select the folder where you extracted the extension files.
-6. The YouTube Shorts Blocker extension should now be installed and active in your browser.
-
-### Mozilla Firefox
-
-1. Download the extension ZIP file from the [latest release](https://github.com/sumanbmondal/youtube-shorts-blocker/releases/latest).
-2. Extract the ZIP file to a folder on your computer.
-3. Open Mozilla Firefox and navigate to `about:debugging#/runtime/this-firefox`.
-4. Click on the "Load Temporary Add-on" button.
-5. Select any file from the extracted folder (e.g., `manifest.json`).
-6. The YouTube Shorts Blocker extension should now be installed and active in your browser.
-
-### Microsoft Edge
-
-1. Download the extension ZIP file from the [latest release](https://github.com/sumanbmondal/youtube-shorts-blocker/releases/latest).
-2. Extract the ZIP file to a folder on your computer.
-3. Open Microsoft Edge and navigate to `edge://extensions`.
-4. Enable "Developer mode" using the toggle switch in the bottom-left corner.
-5. Click on the "Load unpacked" button and select the folder where you extracted the extension files.
-6. The YouTube Shorts Blocker extension should now be installed and active in your browser.
+- For Mozilla Firefox:
+  1. Open Mozilla Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+  2. Click on the "Load Temporary Add-on" button.
+  3. Select any file from the extracted folder (e.g. `manifest.json`).
+- For chromium based browsers
+  1. Open Google Chrome and navigate to `chrome://extensions`. (`edge://extensions` for MS Edge)
+  2. Enable "Developer mode" using the toggle switch in the top-right corner.
+  3. Click on the "Load unpacked" button and select the folder where you extracted the extension files.
+3. The YouTube Shorts Blocker extension should now be installed and active in your browser.
 
 ## Contributing
 
-Contributions are welcome! If you have any ideas, suggestions, or bug fixes, feel free to open an issue or submit a pull request.
+Contributions are welcome!
+If you have any ideas, suggestions, or bug fixes, feel free to open an issue or submit a pull request.
 
 ## License
 


### PR DESCRIPTION
This will allow the user to watch a video, if they actually intend to watch it, without disabling the extension (or pulling up an incognito window where they might start scrolling endlessly).